### PR TITLE
Simplify API by re-integrating telemetry with dataviewer

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,22 +1,25 @@
 FROM python:3.8-slim
 
+RUN apt-get update && apt-get install -y redis-server \
+    && rm -rf /var/cache/apt/lists/*
+
 WORKDIR /api
 ADD requirements.txt /api/requirements.txt
-#RUN apk add --no-cache --virtual .build-deps gcc musl-dev \
-#    && pip install -r requirements.txt \
-#    && apk del .build-deps gcc musl-dev
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt && pip install supervisor
 
 ADD . /api
-ARG DBC_VER=2019.2.1
+ARG DBC_VER=2020.1.0
 RUN apt-get update && apt-get install -y curl \
     && curl -L "https://github.com/WURacing/DBC/archive/$DBC_VER.tar.gz" | tar -xzf - "DBC-$DBC_VER/dbc/$DBC_VER.dbc" \
+	&& apt-get remove --auto-remove -y curl \
     && rm -rf /var/cache/apt/lists/*
 ENV DBC=DBC-$DBC_VER/dbc/$DBC_VER.dbc
 ENV FLASK_APP=dataviewerapi
 ENV PYTHONPATH=/api
 ENV UPLOAD_FOLDER=/data/upload
 ENV DATA_FOLDER=/data/runs
+ENV REDIS_URL=redis://localhost:6379
 EXPOSE 80
-
-CMD ["gunicorn", "dataviewerapi:app", "-b", "0.0.0.0:80", "--log-file", "-", "--access-logfile", "-", "--workers", "4", "--keep-alive", "0"]
+EXPOSE 9999/udp
+VOLUME ["/data"]
+CMD ["supervisord","-c","/api/supervisord.conf"]

--- a/api/dataviewerapi/__init__.py
+++ b/api/dataviewerapi/__init__.py
@@ -29,6 +29,7 @@ app.url_map.converters['date'] = DateConverter
 jobs = []
 
 from . import routes, models, data
+import telemetryapi
 
 
 @app.shell_context_processor

--- a/api/dataviewerapi/config.py
+++ b/api/dataviewerapi/config.py
@@ -17,3 +17,4 @@ class Config(object):
     DBC = os.environ.get("DBC")
     CELERY_BROKER_URL = os.environ.get("REDIS_URL") or 'redis://localhost:6379'
     CELERY_RESULT_BACKEND = os.environ.get("REDIS_URL") or 'redis://localhost:6379'
+    REDIS_URL = os.environ.get("REDIS_URL") or 'redis://localhost:6379'

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,6 +3,7 @@ flask-restful~=0.3.7
 flask-sqlalchemy~=2.4.1
 flask-migrate~=2.5.2
 flask-cors~=3.0.8
+flask-sse
 mysql-connector-python~=8.0.18
 numpy~=1.18.0
 sympy~=1.5
@@ -13,5 +14,6 @@ celery
 cantools
 redis
 gunicorn
+gevent
 boto3
 python-dotenv

--- a/api/supervisord.conf
+++ b/api/supervisord.conf
@@ -1,0 +1,37 @@
+[supervisord]
+nodaemon=true
+
+[program:redis]
+command=redis-server
+autorestart=true
+stderr_logfile=/dev/stdout
+stderr_logfile_maxbytes = 0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes = 0
+
+[program:dataviewerapi] 
+command=gunicorn dataviewerapi:app -b 0.0.0.0:80 --log-file - --access-logfile - --workers 4 --keep-alive 0 --worker-class gevent
+autostart=true
+autorestart=true
+stderr_logfile=/dev/stdout
+stderr_logfile_maxbytes = 0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes = 0
+
+[program:dataviewerworker] 
+command=celery -A dataviewerapi.celery worker --loglevel=info
+autostart=true
+autorestart=true
+stderr_logfile=/dev/stdout
+stderr_logfile_maxbytes = 0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes = 0
+
+[program:telemetryudp] 
+command=python -m telemetryudp
+autostart=true
+autorestart=true
+stderr_logfile=/dev/stdout
+stderr_logfile_maxbytes = 0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes = 0

--- a/api/telemetryapi/__init__.py
+++ b/api/telemetryapi/__init__.py
@@ -1,0 +1,4 @@
+from dataviewerapi import app
+from flask_sse import sse
+
+app.register_blueprint(sse, url_prefix='/api/telemetry')

--- a/api/telemetryudp/__init__.py
+++ b/api/telemetryudp/__init__.py
@@ -1,0 +1,52 @@
+import json
+import os
+import logging
+import struct
+from functools import reduce
+
+import cantools.database
+from redis import StrictRedis
+
+config = {
+    "REDIS_URL": os.environ.get("REDIS_URL") or "redis://localhost:6379",
+    "DBC": os.environ["DBC"],
+}
+
+
+class TelemetryServer:
+    def __init__(self):
+        self.redis = StrictRedis.from_url(config["REDIS_URL"])
+        self.logger = logging.getLogger(__name__ + ".TelemetryServer")
+        self.dbc = cantools.database.load_file(config["DBC"])
+
+    def handle(self, msg: bytes, rinfo):
+        if len(msg) != 20:
+            self.logger.warning(f"Invalid message length {len(msg)} from {rinfo}")
+            return
+
+        frame_id, timestamp, data, checksum, word = struct.unpack("!Ll8sB3s", msg)
+        if word != b"WU\n":
+            self.logger.warning(f"Invalid magic ID {word}")
+            return
+
+        check = reduce(lambda x, y: x ^ y, list(data), checksum)
+        if check != 0:
+            self.logger.warning(f"Checksum failed {check}")
+            return
+
+        try:
+            signals = self.dbc.decode_message(frame_id, data)
+        except KeyError:
+            self.logger.warning(f"Message with id {frame_id} not found in DBC")
+            return
+
+        self.logger.info(f"Received message at {timestamp}")
+
+        for sig_name, sig_val in signals.items():
+            self.post(sig_name, sig_val)
+
+    def post(self, name: str, val: float):
+        msg = {"data": {"key": name, "value": val}}
+        msg = json.dumps(msg)
+        return self.redis.publish(channel="sse", message=msg)
+

--- a/api/telemetryudp/__main__.py
+++ b/api/telemetryudp/__main__.py
@@ -1,0 +1,21 @@
+import socket
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+from . import TelemetryServer
+
+logger = logging.getLogger(__name__)
+
+UDP_IP = "0.0.0.0"
+UDP_PORT = 9999
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)  # UDP
+sock.bind((UDP_IP, UDP_PORT))
+
+logger.info(f"Listening on {UDP_IP}:{UDP_PORT}")
+
+server = TelemetryServer()
+while True:
+    data, addr = sock.recvfrom(20)
+    server.handle(data, addr)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,40 +4,13 @@ services:
   api:
     build: ./api
     container_name: "dataviewerapi"
-    # ports:
-    # - "3001:80"
-    volumes:
-    - "./data:/data"
-    environment:
-      REDIS_URL: "redis://redis:6379"
-      DATABASE_URL: "mysql+mysqlconnector://root:gofastgofast@db/data"
-    networks:
-    - front
-    - back
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.api.rule=PathPrefix(`/api/runs`,`/api/filters`,`/api/variables`)"
-      - "traefik.http.routers.api.entrypoints=web"
-      - "traefik.http.middlewares.gzipme.compress=true"
-      - "traefik.http.routers.api.middlewares=gzipme@docker"
-  
-  worker:
-    build: ./api
-    command: celery -A dataviewerapi.celery worker --loglevel=info
-    volumes:
-    - "./data:/data"
-    environment:
-      REDIS_URL: "redis://redis:6379"
-    networks:
-    - back
-  
-  redis:
-    image: redis:alpine
-    container_name: redis
     ports:
-    - "6379"
-    networks:
-    - back
+    - "3001:80"
+    - "9999:9999/udp"
+    volumes:
+    - "./data:/data"
+    environment:
+      DATABASE_URL: "mysql+mysqlconnector://root:gofastgofast@db/data"
   
   db:
     image: mariadb:10.2
@@ -47,46 +20,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: gofastgofast
       MYSQL_DATABASE: data
-    networks:
-    - front
   
-  telemetry:
-    image: wuracing/telemetryapi
-    environment:
-      REDIS_URL: "redis://redis:6379"
-    ports:
-    - "9999:9999/udp"
-    # - "3002:80"
-    networks:
-    - front
-    - back
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.telemetry.rule=Path(`/api/telemetry`)"
-      - "traefik.http.routers.telemetry.entrypoints=web"
-
-  
-  traefik:
-    image: "traefik:v2.0.0-rc3"
-    container_name: "traefik"
-    command:
-      #- "--log.level=DEBUG"
-      - "--api.insecure=true"
-      - "--providers.docker=true"
-      - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.web.address=:80"
-    ports:
-      - "3001:80"
-      - "8080:8080"
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
-    networks:
-      - front
-      - back
-
-networks:
-  front:
-  back:
 
 # after docker-compose up, you need to run
 #   docker-compose run api flask db upgrade


### PR DESCRIPTION
This also builds all necessary services to run the dataviewer website backend into api/Dockerfile. The motivation is to reduce the complexity in the AWS code deploy.